### PR TITLE
Fix API and compatibility with Bankscrap v2.0.0

### DIFF
--- a/bankscrap-bbva.gemspec
+++ b/bankscrap-bbva.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'bankscrap', '~> 1.0'
+  spec.add_runtime_dependency 'bankscrap', '~> 2.0'
   spec.add_development_dependency 'bundler', '~> 1.7'
   spec.add_development_dependency 'rake', '~> 10.0'
 end

--- a/lib/bankscrap/bbva/bank.rb
+++ b/lib/bankscrap/bbva/bank.rb
@@ -10,9 +10,11 @@ module Bankscrap
       ACCOUNT_ENDPOINT  = '/ENPP/enpp_mult_web_mobility_02/accounts/'.freeze
 
       # BBVA expects an identifier before the actual User Agent, but 12345 works fine
-      USER_AGENT        = SecureRandom.hex(64).upcase + ';iPhone;Apple;iPhone5,2;640x1136;iOS;9.3.2;WOODY;5.1.2;xhdpi'.freeze
-      REQUIRED_CREDENTIALS  = [:user, :password]
-      CONSUMER_ID = '00000013' # this is probably some sort of identifier of Android vs iOS consumer app
+      USER_AGENT = SecureRandom.hex(64).upcase + ';iPhone;Apple;iPhone5,2;640x1136;iOS;9.3.2;WOODY;5.1.2;xhdpi'.freeze
+      REQUIRED_CREDENTIALS = [:user, :password].freeze
+
+      # This is probably some sort of identifier of Android vs iOS consumer app
+      CONSUMER_ID = '00000013'.freeze
 
       def initialize(credentials = {})
         super do
@@ -29,7 +31,7 @@ module Bankscrap
             'Accept-Charset'   => 'UTF-8',
             'Connection'       => 'Keep-Alive',
             'Host'             => 'servicios.bbva.es',
-            'ConsumerID'       => CONSUMER_ID,
+            'ConsumerID'       => CONSUMER_ID
           )
         end
       end
@@ -132,17 +134,17 @@ module Bankscrap
         post(BASE_ENDPOINT + LOGIN_ENDPOINT, fields: params)
 
         # We also need to initialize a session
-        with_headers({'Content-Type' => 'application/json'}) do
+        with_headers('Content-Type' => 'application/json') do
           post(SESSIONS_ENDPOINT, fields: {
             consumerID: CONSUMER_ID
           }.to_json)
         end
 
         # We need to extract the "tsec" header from the last response.
-        # As the Bankscrap core library doesn't expose the headers of each response 
+        # As the Bankscrap core library doesn't expose the headers of each response
         # we have to use Mechanize's HTTP client "current_page" method.
-        tsec = @http.current_page.response["tsec"]
-        add_headers("tsec" => tsec)
+        tsec = @http.current_page.response['tsec']
+        add_headers('tsec' => tsec)
       end
 
       # Build an Account object from API data

--- a/lib/bankscrap/bbva/version.rb
+++ b/lib/bankscrap/bbva/version.rb
@@ -1,5 +1,5 @@
 module Bankscrap
   module BBVA
-    VERSION = '1.0.0'.freeze
+    VERSION = '2.0.0'.freeze
   end
 end


### PR DESCRIPTION
# Background
The Bankscrap BBVA adapter (for individuals, not companies) has been broken for some time due to the latest changes to BBVA's API. These API changes forced the deprecation of the version of the mobile app this adapter was based on.

The new version of the mobile apps (Android and iOS) includes, among other things, SSL certificate pinning. It took some time, but it's finally here 🔥.

The adapter was also not compatible with the version 2 of [Banskcrap core library](https://github.com/bankscrap/bankscrap).

# Changes
* Make adapter compatible with Bankscrap v2 => use Money objects for amounts.
* Updated product endpoint.
* Added new session endpoint (to be called right after the login).
* Added some new headers (`ConsumerID` and `tsec`).
* Updated User-Agent.

## Additional notes
After this PR gets merged and v2.0.0 gets published, we will yank the [v1.0.0 of this adapter's gem](https://rubygems.org/gems/bankscrap-bbva/versions/1.0.0) as it is not working anymore.

You can test this branch before it gets released to rubygems:
```
$ git clone -b feature/bankscrap-v2 https://git@github.com/bankscrap/bankscrap-bbva.git
$ cd bankscrap-bbva
$ rake install
$ bankscrap balance BBVA --credentials=user:YOUR_DNI password:YOUR:PASSWORD
```