### PR TITLE
Monkey patch mechanize to avoid bug with POST requests

### DIFF
--- a/bankscrap-bbva.gemspec
+++ b/bankscrap-bbva.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'bankscrap', '~> 2.0'
+  spec.add_runtime_dependency 'bankscrap', '~> 2.0.3'
   spec.add_development_dependency 'bundler', '~> 1.7'
   spec.add_development_dependency 'rake', '~> 10.0'
 end

--- a/lib/bankscrap-bbva.rb
+++ b/lib/bankscrap-bbva.rb
@@ -1,2 +1,3 @@
 require_relative 'bankscrap/bbva/bank'
 require_relative 'bankscrap/bbva/version'
+require_relative 'monkey_patch/mechanize'

--- a/lib/bankscrap/bbva/version.rb
+++ b/lib/bankscrap/bbva/version.rb
@@ -1,5 +1,5 @@
 module Bankscrap
   module BBVA
-    VERSION = '2.0.0'.freeze
+    VERSION = '2.0.1'.freeze
   end
 end

--- a/lib/monkey_patch/mechanize.rb
+++ b/lib/monkey_patch/mechanize.rb
@@ -1,0 +1,55 @@
+# Extracted from http://scottwb.com/blog/2013/11/09/defeating-the-infamous-mechanize-too-many-connection-resets-bug/
+
+class Mechanize::HTTP::Agent
+  MAX_RESET_RETRIES = 10
+
+  # We need to replace the core Mechanize HTTP method:
+  #
+  #   Mechanize::HTTP::Agent#fetch
+  #
+  # with a wrapper that handles the infamous "too many connection resets"
+  # Mechanize bug that is described here:
+  #
+  #   https://github.com/sparklemotion/mechanize/issues/123
+  #
+  # The wrapper shuts down the persistent HTTP connection when it fails with
+  # this error, and simply tries again. In practice, this only ever needs to
+  # be retried once, but I am going to let it retry a few times
+  # (MAX_RESET_RETRIES), just in case.
+  #
+  def fetch_with_retry(
+    uri,
+    method    = :get,
+    headers   = {},
+    params    = [],
+    referer   = current_page,
+    redirects = 0
+  )
+    action      = "#{method.to_s.upcase} #{uri.to_s}"
+    retry_count = 0
+
+    begin
+      fetch_without_retry(uri, method, headers, params, referer, redirects)
+    rescue Net::HTTP::Persistent::Error => e
+      # Pass on any other type of error.
+      raise unless e.message =~ /too many connection resets/
+
+      # Pass on the error if we've tried too many times.
+      if retry_count >= MAX_RESET_RETRIES
+        puts "**** WARN: Mechanize retried connection reset #{MAX_RESET_RETRIES} times and never succeeded: #{action}" if Bankscrap.debug
+        raise
+      end
+
+      # Otherwise, shutdown the persistent HTTP connection and try again.
+      puts "**** WARN: Mechanize retrying connection reset error: #{action}" if Bankscrap.debug
+      retry_count += 1
+      self.http.shutdown
+      retry
+    end
+  end
+
+  # Alias so #fetch actually uses our new #fetch_with_retry to wrap the
+  # old one aliased as #fetch_without_retry.
+  alias_method :fetch_without_retry, :fetch
+  alias_method :fetch, :fetch_with_retry
+end


### PR DESCRIPTION
For some reason this adapter was hitting [this bug from Mechanize](https://github.com/sparklemotion/mechanize/issues/123) when not setting a proxy (that's why I didn't realize it in the previous PR).

This fixes it by using monkey patching extracted from [here](http://scottwb.com/blog/2013/11/09/defeating-the-infamous-mechanize-too-many-connection-resets-bug/). 

As this is the only adapter who have encountered this bug, I included the monkey patch here and not in the core library. If we find it happens with other adapters, we can move it there.

This PR also sets the minimum version of bankscrap core to v2.0.3 which [removes some thor warnings](https://github.com/bankscrap/bankscrap/commit/4b1e96882210174833d561f4973caa49b48b2356).

PS: I've yanked v2.0.0 from rubygems as it was not working. Minimum working version for this adapter will be v2.0.1